### PR TITLE
Add correct transfer for is_forcing_ field of impact message: #0000001

### DIFF
--- a/knp/backends/cpu/cpu-library/include/knp/backends/cpu-library/impl/blifat_population_impl.h
+++ b/knp/backends/cpu/cpu-library/include/knp/backends/cpu-library/impl/blifat_population_impl.h
@@ -131,7 +131,7 @@ void process_inputs(
             {
                 if (impact.synapse_type_ == synapse_traits::OutputType::EXCITATORY)
                 {
-                    neuron.is_being_forced_ = message.is_forcing_;
+                    neuron.is_being_forced_ |= message.is_forcing_;
                 }
             }
         }

--- a/knp/backends/cpu/cpu-library/include/knp/backends/cpu-library/impl/synaptic_resource_stdp_impl.h
+++ b/knp/backends/cpu/cpu-library/include/knp/backends/cpu-library/impl/synaptic_resource_stdp_impl.h
@@ -146,8 +146,8 @@ template <class NeuronType>
 neuron_traits::ISIPeriodType update_isi(
     neuron_traits::neuron_parameters<neuron_traits::SynapticResourceSTDPNeuron<NeuronType>> &neuron, uint64_t step)
 {
-    if (neuron
-            .is_being_forced_)  // This neuron got a forcing spike this turn and doesn't continue its spiking sequence.
+    // This neuron got a forcing spike this turn and doesn't continue its spiking sequence.
+    if (neuron.is_being_forced_)
     {
         neuron.isi_status_ = neuron_traits::ISIPeriodType::is_forced;
         // Do not update last_step_.
@@ -320,8 +320,8 @@ void do_dopamine_plasticity(
                 if (step - synapse->rule_.last_spike_step_ < synapse->rule_.dopamine_plasticity_period_)
                 {
                     // Change synapse resource.
-                    float d_r = neuron.dopamine_value_ *
-                                std::min(static_cast<float>(std::pow(2, -neuron.stability_)), 1.F) / 1000.0F;
+                    float d_r =
+                        neuron.dopamine_value_ * std::min(static_cast<float>(std::pow(2, -neuron.stability_)), 1.F);
                     synapse->rule_.synaptic_resource_ += d_r;
                     neuron.free_synaptic_resource_ -= d_r;
                 }

--- a/knp/core-library/impl/messaging/fbs/synaptic_impact_message.fbs
+++ b/knp/core-library/impl/messaging/fbs/synaptic_impact_message.fbs
@@ -40,6 +40,7 @@ table SynapticImpactMessage
     header: MessageHeader;
     presynaptic_population_uid: UID;
     postsynaptic_population_uid: UID;
+    is_forcing: bool;
     impacts: [SynapticImpact];
 }
 

--- a/knp/neuron-traits-library/include/knp/neuron-traits/stdp_synaptic_resource_rule.h
+++ b/knp/neuron-traits-library/include/knp/neuron-traits/stdp_synaptic_resource_rule.h
@@ -153,7 +153,7 @@ struct neuron_parameters<SynapticResourceSTDPNeuron<NeuronType>> : public neuron
     /**
      * @brief ISI period status.
      */
-    ISIPeriodType isi_status_ = ISIPeriodType::period_continued;
+    ISIPeriodType isi_status_ = ISIPeriodType::not_in_period;
 
     /**
      * @brief Last non-forced spike step.

--- a/knp/tests/core/message_bus_test.cpp
+++ b/knp/tests/core/message_bus_test.cpp
@@ -122,7 +122,7 @@ TEST(MessageBusSuite, SynapticImpactMessageSendZMQ)
         {knp::core::UID{}},
         knp::core::UID{},
         knp::core::UID{},
-        false,
+        true,
         {{1, 2, synapse_type, 3, 4}, {4, 3, synapse_type, 2, 1}, {7, 8, synapse_type, 9, 10}}};
 
     auto &subscription = ep1.subscribe<SynapticImpactMessage>(knp::core::UID(), {msg.header_.sender_uid_});
@@ -138,6 +138,7 @@ TEST(MessageBusSuite, SynapticImpactMessageSendZMQ)
     EXPECT_EQ(msgs[0].header_.sender_uid_, msg.header_.sender_uid_);
     ASSERT_EQ(msgs[0].presynaptic_population_uid_, msg.presynaptic_population_uid_);
     ASSERT_EQ(msgs[0].postsynaptic_population_uid_, msg.postsynaptic_population_uid_);
+    ASSERT_EQ(msgs[0].is_forcing_, msg.is_forcing_);
     ASSERT_EQ(msgs[0].impacts_, msg.impacts_);
 }
 
@@ -153,7 +154,7 @@ TEST(MessageBusSuite, SynapticImpactMessageSendCPU)
         {knp::core::UID{}},
         knp::core::UID{},
         knp::core::UID{},
-        false,
+        true,
         {{1, 2, synapse_type, 3, 4}, {4, 3, synapse_type, 2, 1}, {7, 8, synapse_type, 9, 10}}};
 
     auto &subscription = ep1.subscribe<SynapticImpactMessage>(knp::core::UID(), {msg.header_.sender_uid_});
@@ -169,5 +170,6 @@ TEST(MessageBusSuite, SynapticImpactMessageSendCPU)
     EXPECT_EQ(msgs[0].header_.sender_uid_, msg.header_.sender_uid_);
     ASSERT_EQ(msgs[0].presynaptic_population_uid_, msg.presynaptic_population_uid_);
     ASSERT_EQ(msgs[0].postsynaptic_population_uid_, msg.postsynaptic_population_uid_);
+    ASSERT_EQ(msgs[0].is_forcing_, msg.is_forcing_);
     ASSERT_EQ(msgs[0].impacts_, msg.impacts_);
 }

--- a/knp/tests/core/messaging_test.cpp
+++ b/knp/tests/core/messaging_test.cpp
@@ -50,10 +50,11 @@ TEST(MessageSuite, ImpactToChannelTest)
 {
     const knp::core::UID uid{true}, pre_uid{true}, post_uid{true};
     const size_t time = 7;
+    const bool forcing = true;
     const knp::synapse_traits::OutputType type = knp::synapse_traits::OutputType::DOPAMINE;
     const std::vector<knp::core::messaging::SynapticImpact> impacts{{1, 2, type, 3, 4}, {5, 6, type, 7, 8}};
 
-    const knp::core::messaging::SynapticImpactMessage message_in{{uid, time}, pre_uid, post_uid, false, impacts};
+    const knp::core::messaging::SynapticImpactMessage message_in{{uid, time}, pre_uid, post_uid, forcing, impacts};
     knp::core::messaging::SynapticImpactMessage message_out;
 
     std::stringstream stream;
@@ -65,6 +66,7 @@ TEST(MessageSuite, ImpactToChannelTest)
     ASSERT_EQ(message_out.header_.send_time_, time);
     ASSERT_EQ(message_out.presynaptic_population_uid_, pre_uid);
     ASSERT_EQ(message_out.postsynaptic_population_uid_, post_uid);
+    ASSERT_EQ(message_out.is_forcing_, forcing);
     ASSERT_EQ(message_out.impacts_, impacts);
 }
 


### PR DESCRIPTION
Fixing issue #1, SynapticImpactMessage used to have its parameter "is_forcing_" transferred incorrectly. Updated protobuf and corresponding files.