### PR TITLE
Small fixes to support MacOS XCode compiler

### DIFF
--- a/knp/backends/cpu/cpu-library/include/knp/backends/cpu-library/delta_synapse_projection.h
+++ b/knp/backends/cpu/cpu-library/include/knp/backends/cpu-library/delta_synapse_projection.h
@@ -57,7 +57,7 @@ void calculate_delta_synapse_projection(
  */
 template <class DeltaLikeSynapse>
 void calculate_projection_part(
-    knp::core::Projection<DeltaLikeSynapse> &projection, const std::unordered_map<size_t, size_t> &message_in_data,
+    knp::core::Projection<DeltaLikeSynapse> &projection, const std::unordered_map<knp::core::Step, size_t> &message_in_data,
     MessageQueue &future_messages, uint64_t step_n, size_t part_start, size_t part_size, std::mutex &mutex)
 {
     calculate_projection_part_impl(projection, message_in_data, future_messages, step_n, part_start, part_size, mutex);

--- a/knp/backends/cpu/cpu-library/include/knp/backends/cpu-library/impl/delta_synapse_projection_impl.h
+++ b/knp/backends/cpu/cpu-library/include/knp/backends/cpu-library/impl/delta_synapse_projection_impl.h
@@ -49,7 +49,7 @@ using MessageQueue = std::unordered_map<uint64_t, knp::core::messaging::Synaptic
 
 template <class DeltaLikeSynapse>
 void calculate_projection_part_impl(
-    knp::core::Projection<DeltaLikeSynapse> &projection, const std::unordered_map<size_t, size_t> &message_in_data,
+    knp::core::Projection<DeltaLikeSynapse> &projection, const std::unordered_map<knp::core::Step, size_t> &message_in_data,
     MessageQueue &future_messages, uint64_t step_n, size_t part_start, size_t part_size, std::mutex &mutex);
 
 
@@ -129,7 +129,7 @@ MessageQueue::const_iterator calculate_delta_synapse_projection_data(
 
 template <class DeltaLikeSynapse>
 void calculate_projection_part_impl(
-    knp::core::Projection<DeltaLikeSynapse> &projection, const std::unordered_map<size_t, size_t> &message_in_data,
+    knp::core::Projection<DeltaLikeSynapse> &projection, const std::unordered_map<knp::core::Step, size_t> &message_in_data,
     MessageQueue &future_messages, uint64_t step_n, size_t part_start, size_t part_size, std::mutex &mutex)
 {
     size_t part_end = std::min(part_start + part_size, projection.size());
@@ -191,7 +191,7 @@ void calculate_projection_part_impl(
  */
 inline std::unordered_map<uint64_t, size_t> convert_spikes(const core::messaging::SpikeMessage &message)
 {
-    std::unordered_map<size_t, size_t> result;
+    std::unordered_map<knp::core::Step, size_t> result;
     for (auto neuron_idx : message.neuron_indexes_)
     {
         auto iter = result.find(neuron_idx);

--- a/knp/base-framework/impl/storage/native/data_storage_common.cpp
+++ b/knp/base-framework/impl/storage/native/data_storage_common.cpp
@@ -36,7 +36,7 @@ std::vector<knp::core::messaging::SpikeMessage> convert_node_time_arrays_to_mess
 {
     if (nodes.size() != timestamps.size()) throw std::runtime_error("Different array sizes: nodes and timestamps.");
     using Message = knp::core::messaging::SpikeMessage;
-    std::unordered_map<size_t, Message> message_map;  // This is a result buffer.
+    std::unordered_map<knp::core::Step, Message> message_map;  // This is a result buffer.
     for (size_t i = 0; i < timestamps.size(); ++i)
     {
         auto step = static_cast<knp::core::Step>(timestamps[i] / time_per_step);

--- a/knp/base-framework/include/knp/framework/monitoring/observer.h
+++ b/knp/base-framework/include/knp/framework/monitoring/observer.h
@@ -69,6 +69,11 @@ public:
     }
 
     /**
+     * @brief Avoid copy assignment of MessageObserver.
+     */
+    MessageObserver& operator=(const MessageObserver&) = delete;
+    
+    /**
      * @brief Move constructor for observer.
      * @param other other observer.
      */

--- a/knp/core-library/include/knp/core/message_endpoint.h
+++ b/knp/core-library/include/knp/core/message_endpoint.h
@@ -118,7 +118,7 @@ public:
     /**
      * @brief Avoid copy assignment of an endpoint.
      */
-    MessageEndpoint &operator=(MessageEndpoint &) = delete;
+    MessageEndpoint &operator=(const MessageEndpoint &) = delete;
 
     /**
      * @brief Message endpoint destructor.


### PR DESCRIPTION
- Fixed const copy assignment operators
    Fixed size_t/uint64_t mixing in message maps because not everywhere size_t == uint64_t
- Fixed const copy assignment operators