### PR TITLE
ci: fix Docker image builds

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -27,6 +27,9 @@ on:
 jobs:
   linux_build:
     runs-on: ${{ matrix.os }}
+    env:
+      DOCKERHUB_LOGIN: ${{ vars.DOCKERHUB_LOGIN || 'kasperskydh' }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
@@ -63,10 +66,17 @@ jobs:
         shell: bash
         run: |
           echo "build-output-dir=build_${{ matrix.c_compiler }}" >> "$GITHUB_OUTPUT"
+          echo "KNP_IMAGE_VERSION=v2.0.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
       - name: Set environment
+        shell: bash
         run: |
-          echo "KNP_IMAGE_VERSION=v2.0.${{ github.run_number }}" >> $GITHUB_ENV
-          echo "KNP_BUILD_IMAGE_NAME=${{ vars.DOCKERHUB_LOGIN }}/knp-build-image:latest" >> $GITHUB_ENV
+          dockerhub_login="${{ vars.DOCKERHUB_LOGIN }}"
+          if [ -z "$dockerhub_login" ]; then
+            dockerhub_login="kasperskydh"
+          fi
+          echo "DOCKERHUB_LOGIN=${dockerhub_login}" >> "$GITHUB_ENV"
+          echo "KNP_BUILD_IMAGE_NAME=${dockerhub_login}/knp-build-image:latest" >> "$GITHUB_ENV"
+          echo "KNP_SDK_IMAGE_NAME=${dockerhub_login}/knp-sdk-image" >> "$GITHUB_ENV"
 
       # Install support for non-x86 emulation in Docker via QEMU.
       # Platforms: linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x,
@@ -81,6 +91,7 @@ jobs:
         run: |
           echo "KNP_IMAGE_VERSION = ${{ steps.strings.outputs.KNP_IMAGE_VERSION }}"
           echo "KNP_BUILD_IMAGE_NAME = ${{ env.KNP_BUILD_IMAGE_NAME }}"
+          echo "KNP_SDK_IMAGE_NAME = ${{ env.KNP_SDK_IMAGE_NAME }}"
       - name: Configure
         run: >
           docker run --platform=linux/${{ matrix.arch }} --rm -v ${{ github.workspace }}:/KNP -w /KNP kasperskydh/knp-build-image cmake -B ${{ steps.strings.outputs.build-output-dir }}
@@ -118,32 +129,30 @@ jobs:
 
       - name: Copy SDK image files to build directory
         if: matrix.c_compiler == 'gcc'
-        run:
+        run: |
           sudo cp -a ${{ github.workspace }}/docker/sdk-image/** ${{ steps.strings.outputs.build-output-dir }}/_packages/
 
       - name: Login to Docker Hub
+        if: matrix.c_compiler == 'gcc' && github.event_name != 'pull_request' && env.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_LOGIN }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_LOGIN }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Create SDK Docker image
-        if: matrix.c_compiler == 'gcc'
-        uses: docker/build-push-action@v7
+        if: matrix.c_compiler == 'gcc' && github.event_name != 'pull_request' && env.DOCKERHUB_TOKEN != ''
+        uses: docker/build-push-action@v6
+        timeout-minutes: 180
+        continue-on-error: false
         with:
           platforms: linux/${{ matrix.arch }}
           context: ${{ steps.strings.outputs.build-output-dir }}/_packages/
-          load: true
           push: true
           build-args: |
             KNP_IMAGE_VERSION=latest
-            KNP_VERSION=2.0.0
-
           tags: |
-            ${{ vars.DOCKERHUB_LOGIN }}/knp-sdk-image:${{ env.KNP_IMAGE_VERSION }}
-            ${{ vars.DOCKERHUB_LOGIN }}/knp-sdk-image:latest
-          timeout-minutes: 180
-          continue-on-error: false
+            ${{ env.KNP_SDK_IMAGE_NAME }}:${{ steps.strings.outputs.KNP_IMAGE_VERSION }}
+            ${{ env.KNP_SDK_IMAGE_NAME }}:latest
 
       - name: Upload deb packages
         if: matrix.c_compiler == 'gcc'
@@ -177,8 +186,10 @@ jobs:
             cpp_compiler: clang++
             boost_install_dir: /Users/runner/work/boost/knp
             boost_version: 1.91.0
-            boost_platform_version: 26
+            boost_platform_version: 15
             boost_toolset: clang
+            boost_arch: aarch64
+            opencv_cmake_args: -DOpenCV_DIR=/opt/homebrew/opt/opencv/lib/cmake/opencv4
           - os: windows-2022
             c_compiler: cl
             cpp_compiler: cl
@@ -186,6 +197,8 @@ jobs:
             boost_version: 1.81.0
             boost_platform_version: 2022
             boost_toolset: msvc
+            boost_arch: x86
+            opencv_cmake_args: -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
         exclude:
           - os: windows-2022
             c_compiler: clang
@@ -214,10 +227,15 @@ jobs:
             boost_install_dir: ${{ matrix.boost_install_dir }}
             platform_version: ${{ matrix.boost_platform_version }}
             toolset: ${{ matrix.boost_toolset }}
+            arch: ${{ matrix.boost_arch }}
 
       - name: Install OpenCV via vcpkg
         if: matrix.c_compiler == 'cl'
         run: vcpkg install opencv:x64-windows
+
+      - name: Install OpenCV via Homebrew
+        if: matrix.os == 'macos-26'
+        run: brew install opencv
 
       - name: Configure CMake
         env:
@@ -227,6 +245,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
           -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          ${{ matrix.opencv_cmake_args }}
           -S .
 
       - name: Build

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_LOGIN: ${{ vars.DOCKERHUB_LOGIN || 'kasperskydh' }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Set Images Version
         run: echo "KNP_IMAGE_VERSION=v2.0.${{ github.run_number }}" >> $GITHUB_ENV
@@ -37,33 +40,30 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_LOGIN }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_LOGIN }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Build and push the base Docker image for Kaspersky Neuromorphic Platform
         uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker/base-image"
           load: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' && env.DOCKERHUB_TOKEN != '' }}
           tags: |
-            ${{ vars.DOCKERHUB_LOGIN }}/knp-base-image:${{ env.KNP_IMAGE_VERSION }}
-            ${{ vars.DOCKERHUB_LOGIN }}/knp-base-image:latest
+            ${{ env.DOCKERHUB_LOGIN }}/knp-base-image:${{ env.KNP_IMAGE_VERSION }}
+            ${{ env.DOCKERHUB_LOGIN }}/knp-base-image:latest
           build-args: KNP_IMAGE_VERSION=${{ env.KNP_IMAGE_VERSION }}
-          timeout-minutes: 180
-          continue-on-error: false
       - name: Build and push the Docker image for Kaspersky Neuromorphic Platform build
         uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:docker/build-image"
           load: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' && env.DOCKERHUB_TOKEN != '' }}
           build-args: KNP_IMAGE_VERSION=${{ env.KNP_IMAGE_VERSION }}
           tags: |
-            ${{ vars.DOCKERHUB_LOGIN }}/knp-build-image:${{ env.KNP_IMAGE_VERSION }}
-            ${{ vars.DOCKERHUB_LOGIN }}/knp-build-image:latest
-          timeout-minutes: 180
-          continue-on-error: false
+            ${{ env.DOCKERHUB_LOGIN }}/knp-build-image:${{ env.KNP_IMAGE_VERSION }}
+            ${{ env.DOCKERHUB_LOGIN }}/knp-build-image:latest

--- a/docker/sdk-image/Dockerfile
+++ b/docker/sdk-image/Dockerfile
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 ARG KNP_IMAGE_VERSION=2.0.0
-ARG KNP_VERSION=2.0.0
 ARG TARGETPLATFORM
 
 FROM kasperskydh/knp-base-image:${KNP_IMAGE_VERSION}
@@ -40,10 +39,4 @@ RUN \
 COPY NOTICE.txt .
 COPY *.deb /knp/
 
-RUN DEBIAN_FRONTEND=noninteractive dpkg -i \
-  /knp/knp-cpp-framework_2.0.0_amd64.deb /knp/knp-cpp-framework-dev_2.0.0_amd64.deb \
-  /knp/knp-documentation_2.0.0_all.deb knp-examples_2.0.0_amd64.deb \
-  /knp/knp-cpu-single-threaded-backend_2.0.0_amd64.deb /knp/knp-cpu-single-threaded-backend-dev_2.0.0_amd64.deb \
-  /knp/knp-cpu-multi-threaded-backend_2.0.0_amd64.deb /knp/knp-cpu-multi-threaded-backend-dev_2.0.0_amd64.deb \
-  /knp/knp-examples_2.0.0_amd64.deb \
-  /knp/knp-python3-framework_2.0.0_amd64.deb
+RUN DEBIAN_FRONTEND=noninteractive dpkg -i /knp/*.deb


### PR DESCRIPTION
Moves the Docker and CMake workflow fixes out of PR #202 into a separate pull request.

Changes:
- add fallback Docker Hub namespace handling for CI workflows;
- skip Docker Hub login and image publishing on pull request builds or when the token is unavailable;
- build SDK images from generated package artifacts;
- install OpenCV for non-Linux CI targets;
- simplify SDK image package installation to use generated `.deb` files.

Validation: not run locally; this PR changes GitHub Actions workflow configuration.
